### PR TITLE
Signed-off-by: Joey Smith <jsmith@webinertia.net>

### DIFF
--- a/src/ConfigManager.php
+++ b/src/ConfigManager.php
@@ -20,7 +20,8 @@ final class ConfigManager extends AbstractListenerAggregate
         // If save/write fails stop propagation so the cache will not be busted
         $this->listeners[] = $events->attach(
             Event\ConfigEvent::EVENT_CONFIG_SAVE,
-            [$this, 'onSaveConfig', $priority]
+            [$this, 'onSaveConfig'],
+            $priority
         );
 
         /**
@@ -30,17 +31,20 @@ final class ConfigManager extends AbstractListenerAggregate
          */
         $this->listeners[] = $events->attach(
             Event\ConfigEvent::EVENT_CONFIG_SAVE,
-            [$this, 'onBustCache', 0]
+            [$this, 'onBustCache'],
+            0
         );
 
         $this->listeners[] = $events->attach(
             Event\ConfigEvent::EVENT_BUST_CACHE,
-            [$this, 'onBustCache', $priority]
+            [$this, 'onBustCache'],
+            $priority
         );
 
         $this->listeners[] = $events->attach(
             Event\ConfigEvent::EVENT_CONFIG_LOAD,
-            [$this, 'onLoadConfig', $priority]
+            [$this, 'onLoadConfig'],
+            $priority
         );
     }
 


### PR DESCRIPTION
Priority was being passed as an array value in argument two, when it was supposed to be argument 3. Caused a callable error.